### PR TITLE
Create ownershiptransfer-lockout

### DIFF
--- a/vulnerable/stephanegosselin/ownership-lockout/ownershiptransfer-lockout
+++ b/vulnerable/stephanegosselin/ownership-lockout/ownershiptransfer-lockout
@@ -1,0 +1,21 @@
+pragma solidity ^0.4.11;
+
+import './Z_StandardToken.sol';
+import './Z_Pausable.sol';
+
+/**
+ * Pausable token
+ *
+ * Simple ERC20 Token example, with pausable token creation
+ **/
+
+contract PausableToken is StandardToken, Pausable {
+
+  function transfer(address _to, uint _value) whenNotPaused returns (bool) {
+    return super.transfer(_to, _value);
+  }
+
+  function transferFrom(address _from, address _to, uint _value) whenNotPaused returns (bool) {
+    return super.transferFrom(_from, _to, _value);
+  }
+}


### PR DESCRIPTION
This contract is transfers the ownership of the pausable token, but fails once ownership is transferred to a contract.